### PR TITLE
Rename address alias field

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The library requires certain environment variables to be defined:
 Optionally, the following variables can be set to bypass safeguards:
 
 - `MULTIBAAS_ALLOW_UPDATE_CONTRACT=true`: Allows contracts to be reuploaded and labelled as an already existing version in MultiBaas, even if the bytecode changes.
-- `MULTIBAAS_ALLOW_UPDATE_ADDRESS=true`: Allows addresses to be updated in MultiBaas if the address label conflicts.
+- `MULTIBAAS_ALLOW_UPDATE_ADDRESS=true`: Allows addresses to be updated in MultiBaas if the address alias conflicts.
 
 If you choose to set these variables using an `.env` file, since the `MULTIBAAS_API_KEY` grants full admin access to the MultiBaas deployment, we strongly advise against checking it into source control.
 
@@ -79,8 +79,8 @@ contract CounterScript is Script {
         // Upload and link the second contract in MultiBaas with custom options
         bytes memory encodedOptions = MultiBaas.withOptions(
             "counter", // Arbitrary MultiBaas label for the uploaded contract code and associated ABI
-            "counter", // Arbitrary MultiBaas label for the address at which the contract is deployed
-            "1.5", // Arbitrary MultiBaas version label for the uploaded contract code and associated ABI
+            "counter", // Arbitrary MultiBaas alias for the address at which the contract is deployed
+            "1.5", // Arbitrary MultiBaas version string for the uploaded contract code and associated ABI
             "-50" // Start syncing events from 50 blocks prior to the current network block
         );
         MultiBaas.linkContractWithOptions("Counter", address(secondCounter), encodedOptions);
@@ -114,8 +114,8 @@ The `forge-multibaas` library provides the following key functions:
 ```solidity
 bytes memory encodedOptions = MultiBaas.withOptions(
     "custom_contract_label", // Arbitrary MultiBaas label for the uploaded contract code and associated ABI
-    "custom_address_label", // Arbitrary MultiBaas label for the address at which the contract is deployed
-    "1.0", // Arbitrary MultiBaas version label for the uploaded contract code and associated ABI
+    "custom_address_alias", // Arbitrary MultiBaas alias for the address at which the contract is deployed
+    "1.0", // Arbitrary MultiBaas version string for the uploaded contract code and associated ABI
     "-100" // Start syncing events from 100 blocks prior to the current network block
 );
 MultiBaas.linkContractWithOptions("MyContract", address(myContract), encodedOptions);
@@ -126,6 +126,6 @@ MultiBaas.linkContractWithOptions("MyContract", address(myContract), encodedOpti
 You can customize the following options when linking contracts:
 
 - **`contractLabel`**: The label for the contract. Defaults to the contract name in lowercase.
-- **`addressLabel`**: The label for the contract address. Defaults to the contract name in lowercase.
-- **`contractVersion`**: The version label for the contract. Defaults to `1.0` and if left empty it auto-increments as the contract bytecode changes. If it is set to a version string that is already uploaded to MultiBaas, but the contract bytecode has changed, then the `MULTIBAAS_ALLOW_UPDATE_CONTRACT` environment variable must be set to `true` to allow for the version label to be reused on the new contract bytecode.
+- **`addressAlias`**: The alias for the deployed contract address. Defaults to the contract name in lowercase.
+- **`contractVersion`**: The version string for the contract. Defaults to `1.0` and if left empty it auto-increments as the contract bytecode changes. If it is set to a version string that is already uploaded to MultiBaas, but the contract bytecode has changed, then the `MULTIBAAS_ALLOW_UPDATE_CONTRACT` environment variable must be set to `true` to allow for the version string to be reused on the new contract bytecode.
 - **`startingBlock`**: The block number from which to start syncing events in MultiBaas. Negative values represent blocks before the current block; non-negative values represent absolute block numbers on the blockchain. `"latest"` represents the current block. If unspecified, it defaults to `"-100"`.

--- a/main.py
+++ b/main.py
@@ -209,15 +209,17 @@ def create_address(
 
     # Generate a unique address alias if the default is conflicting
     if address_alias == contract_label:
-        # Check for similar labels and generate a new one if necessary
-        similar_labels = mb_request(
+        # Retrieve all addresses and extract aliases
+        all_addresses = mb_request(
             mb_url,
             mb_api_key,
-            f"/chains/ethereum/addresses/similarlabels/{contract_label}",
+            "/chains/ethereum/addresses",
         )
-        similar_set = set(label_info["label"] for label_info in similar_labels)
-        if contract_label in similar_set:
-            # Add a numeric suffix to create a unique label
+        similar_set = set(addr["alias"] for addr in all_addresses if "alias" in addr)
+        if contract_label not in similar_set:
+            address_alias = contract_label
+        else:
+            # Add a numeric suffix to create a unique alias
             num = 2
             while f"{contract_label}{num}" in similar_set:
                 num += 1

--- a/main.py
+++ b/main.py
@@ -471,7 +471,7 @@ def upload_and_link_contract(
     """
     contract_label = options.get("contractLabel", contract_name.lower())
     contract_version = options.get("contractVersion", None)
-    address_alias = options.get("addressAlias", contract_label)
+    address_alias = options.get("addressAlias", None)
     starting_block = options.get("startingBlock", "-100")
 
     # Create the contract

--- a/main.py
+++ b/main.py
@@ -164,17 +164,17 @@ def validate_api_key(mb_url: str, mb_api_key: str) -> bool:
 
 
 def create_address(
-    mb_url: str, mb_api_key: str, address: str, contract_label: str, address_label: str
+    mb_url: str, mb_api_key: str, address: str, contract_label: str, address_alias: str
 ) -> Optional[Dict]:
     """
-    Creates an address in MultiBaas, handling label conflicts and updates.
+    Creates an address in MultiBaas, handling alias conflicts and updates.
 
     Args:
         mb_url (str): The MultiBaas URL.
         mb_api_key (str): The API key for authentication.
         address (str): The Ethereum address to create.
         contract_label (str): The label for the contract.
-        address_label (str): The label for the address.
+        address_alias (str): The alias for the address.
 
     Returns:
         Optional[Dict]: The created address information or None if failed.
@@ -188,18 +188,18 @@ def create_address(
         # Check if the address already exists
         result = mb_request(mb_url, mb_api_key, f"/chains/ethereum/addresses/{address}")
 
-        # If the address exists, handle any conflicting labels
-        if result and result.get("label", "") != "":
-            existing_label = result["label"]
+        # If the address exists, handle any conflicting aliases
+        if result and result.get("alias", "") != "":
+            existing_alias = result["alias"]
 
-            if existing_label != address_label:
+            if existing_alias != address_alias:
                 raise MultiBaasAPIError(
                     f"/chains/ethereum/addresses/{address}",
                     409,
-                    f"The address {address} has already been created under a different label '{existing_label}'",
+                    f"The address {address} has already been created under a different alias '{existing_alias}'",
                 )
 
-            print(f"Address {address} already created as '{existing_label}'")
+            print(f"Address {address} already created as '{existing_alias}'")
             return result
 
     except MultiBaasAPIError as e:
@@ -207,8 +207,8 @@ def create_address(
             raise  # Re-raise exception if it's not a 404 Not Found error
         # If the address is not found (404), proceed to create the address
 
-    # Generate a unique address label if the default is conflicting
-    if address_label == contract_label:
+    # Generate a unique address alias if the default is conflicting
+    if address_alias == contract_label:
         # Check for similar labels and generate a new one if necessary
         similar_labels = mb_request(
             mb_url,
@@ -221,44 +221,44 @@ def create_address(
             num = 2
             while f"{contract_label}{num}" in similar_set:
                 num += 1
-            address_label = f"{contract_label}{num}"
+            address_alias = f"{contract_label}{num}"
     else:
         try:
-            # Check if the label already exists
+            # Check if the alias already exists
             result = mb_request(
-                mb_url, mb_api_key, f"/chains/ethereum/addresses/{address_label}"
+                mb_url, mb_api_key, f"/chains/ethereum/addresses/{address_alias}"
             )
 
             if not allow_update_address:
                 raise MultiBaasAPIError(
-                    f"/chains/ethereum/addresses/{address_label}",
+                    f"/chains/ethereum/addresses/{address_alias}",
                     409,
-                    f"Another address has already been created under the label '{address_label}'",
+                    f"Another address has already been created under the alias '{address_alias}'",
                 )
 
             # If allow_update_address is True, delete the conflicting address
             if result and result.get("address", "") != "":
                 old_address = result["address"]
                 print(
-                    f"Deleting old address {old_address} with label '{address_label}'"
+                    f"Deleting old address {old_address} with alias '{address_alias}'"
                 )
                 mb_request(
                     mb_url,
                     mb_api_key,
-                    f"/chains/ethereum/addresses/{address_label}",
+                    f"/chains/ethereum/addresses/{address_alias}",
                     method="DELETE",
                 )
 
         except MultiBaasAPIError as e:
             if e.status_code != 404:
                 raise  # Re-raise exception if it's not a 404 Not Found error
-            # If the label is not found (404), proceed to create the address
+            # If the alias is not found (404), proceed to create the address
 
     # Create the new address
-    print(f"Creating address {address} with label '{address_label}'")
+    print(f"Creating address {address} with alias '{address_alias}'")
     data = {
         "address": address,
-        "label": address_label,
+        "alias": address_alias,
     }
     try:
         created_address = mb_request(
@@ -424,7 +424,7 @@ def link_contract_to_address(
     mb_api_key: str,
     contract_label: str,
     contract_version: Optional[str],
-    address_label: str,
+    address_alias: str,
     starting_block: str,
 ) -> None:
     """
@@ -435,7 +435,7 @@ def link_contract_to_address(
         mb_api_key (str): The API key for authentication.
         contract_label (str): The label of the contract.
         contract_version (str, optional): The version of the contract.
-        address_label (str): The label of the address.
+        address_alias (str): The alias of the address.
         starting_block (str): The starting block for event syncing.
     """
     data = {
@@ -447,7 +447,7 @@ def link_contract_to_address(
         mb_request(
             mb_url,
             mb_api_key,
-            f"/chains/ethereum/addresses/{address_label}/contracts",
+            f"/chains/ethereum/addresses/{address_alias}/contracts",
             method="POST",
             data=data,
         )
@@ -473,11 +473,11 @@ def upload_and_link_contract(
         artifact_dir (str): The directory where artifacts are stored.
         contract_name (str): The name of the contract.
         contract_address (str): The Ethereum address of the contract.
-        options (dict): Additional options for contract and address labeling.
+        options (dict): Additional options for contract labeling and address aliasing.
     """
     contract_label = options.get("contractLabel", contract_name.lower())
     contract_version = options.get("contractVersion", None)
-    address_label = options.get("addressLabel", contract_label)
+    address_alias = options.get("addressAlias", contract_label)
     starting_block = options.get("startingBlock", "-100")
 
     # Create the contract
@@ -495,7 +495,7 @@ def upload_and_link_contract(
 
     # Create the address
     mb_address = create_address(
-        mb_url, mb_api_key, contract_address, contract_label, address_label
+        mb_url, mb_api_key, contract_address, contract_label, address_alias
     )
     if not mb_address:
         print("Error: Failed to create address. Stopping execution.")
@@ -508,7 +508,7 @@ def upload_and_link_contract(
             mb_api_key,
             contract_label,
             mb_contract.get("version"),
-            address_label,
+            address_alias,
             starting_block,
         )
         print("Contract linked successfully.")

--- a/main.py
+++ b/main.py
@@ -208,6 +208,8 @@ def create_address(
         # If the address is not found (404), proceed to create the address
 
     # If no alias was provided, attempt to use the contract_label, then fall back to label2, label3, etc.
+    print(f"Address alias set to {address_alias}'")
+
     if not address_alias:
         all_addresses = mb_request(
             mb_url,

--- a/main.py
+++ b/main.py
@@ -489,7 +489,6 @@ def upload_and_link_contract(
     mb_address = create_address(
         mb_url, mb_api_key, contract_address, contract_label, address_alias
     )
-    print(f"Address created successfully: {mb_address}")
     if not mb_address:
         print("Error: Failed to create address. Stopping execution.")
         return
@@ -501,7 +500,7 @@ def upload_and_link_contract(
             mb_api_key,
             contract_label,
             mb_contract.get("version"),
-            address_alias,
+            mb_address.get("alias"),
             starting_block,
         )
         print("Contract linked successfully.")

--- a/main.py
+++ b/main.py
@@ -207,10 +207,8 @@ def create_address(
             raise  # Re-raise exception if it's not a 404 Not Found error
         # If the address is not found (404), proceed to create the address
 
-    # If no alias was provided, attempt to use the contract_label, then fall back to label2, label3, etc.
-    print(f"Address alias set to {address_alias}'")
-
     if not address_alias:
+        # If no alias was provided, attempt to use the contract_label, then fall back to label2, label3, etc.
         all_addresses = mb_request(
             mb_url,
             mb_api_key,
@@ -491,6 +489,7 @@ def upload_and_link_contract(
     mb_address = create_address(
         mb_url, mb_api_key, contract_address, contract_label, address_alias
     )
+    print(f"Address created successfully: {mb_address}")
     if not mb_address:
         print("Error: Failed to create address. Stopping execution.")
         return

--- a/src/MultiBaas.sol
+++ b/src/MultiBaas.sol
@@ -9,20 +9,20 @@ library MultiBaas {
 
     // Encode options for uploading and linking a contract MultiBaas
     // @param contractLabel: Label for the contract. Defaults to contract name if empty
-    // @param addressLabel: Label for the contract address. Defaults to contract name if empty
-    // @param contractVersion: Version label for the contract. Defaults to 1.0 and auto increments if empty
+    // @param addressAlias: Alias for the deployed contract address. Defaults to contract name if empty
+    // @param contractVersion: Version string for the contract. Defaults to 1.0 and auto increments if empty
     // @param startingBlock: From which block to start syncing events. Defaults to -100. If a negative value, it represents blocks before the current block. If a positive value, it represents the absolute block number. If 0, it represents the latest block.
     function withOptions(
         string memory contractLabel,
-        string memory addressLabel,
+        string memory addressAlias,
         string memory contractVersion,
         string memory startingBlock
     ) internal pure returns (bytes memory encodedOptions) {
         encodedOptions = abi.encodePacked(
             '{"contractLabel":"',
             contractLabel,
-            '","addressLabel":"',
-            addressLabel,
+            '","addressAlias":"',
+            addressAlias,
             '","contractVersion":"',
             contractVersion,
             '","startingBlock":"',


### PR DESCRIPTION
Use address alias instead of address label

Instead of using deprecated similar labels endpoint, just compare against all registered address aliases

Also resolves #1 